### PR TITLE
Change server stream server api

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,14 +454,13 @@ interface QueueServiceServer
     ): \Google\Protobuf\Empty_;
 
     /**
-     * @param Server\ServerStreamChannel<\Google\Protobuf\Empty_, \Thesis\Api\V1\Message> $stream
+     * @return iterable<array-key, \Thesis\Api\V1\Message>
      */
     public function pull(
         \Google\Protobuf\Empty_ $request,
-        Server\ServerStreamChannel $stream,
         Metadata $md,
         Cancellation $cancellation,
-    ): void;
+    ): iterable;
 
     /**
      * @param Server\BidirectionalStreamChannel<\Thesis\Api\V1\Heartbeat, \Thesis\Api\V1\Heartbeat> $stream

--- a/src/Plugin/Generator/GrpcGenerator.php
+++ b/src/Plugin/Generator/GrpcGenerator.php
@@ -212,7 +212,7 @@ PHP,
 
         $useStreaming = array_any(
             $service->methods,
-            static fn(Parser\ServiceMethodDescriptor $method) => $method->clientStreaming || $method->serverStreaming,
+            static fn(Parser\ServiceMethodDescriptor $method) => $method->clientStreaming || $method->bidirectionalStreaming,
         );
 
         if ($useStreaming) {

--- a/src/Plugin/Generator/GrpcGenerator.php
+++ b/src/Plugin/Generator/GrpcGenerator.php
@@ -254,12 +254,11 @@ PHP,
                 $interfaceMethod
                     ->setParameters([
                         new Parameter('request')->setType($in->fqcn),
-                        new Parameter('stream')->setType('Server\ServerStreamChannel'),
                         new Parameter('md')->setType('Metadata'),
                         new Parameter('cancellation')->setType('Cancellation'),
                     ])
-                    ->setReturnType('void')
-                    ->addComment("{$phpdocPrefix}@param Server\\ServerStreamChannel<{$in->fqcn}, {$out->fqcn}> \$stream");
+                    ->setReturnType('iterable')
+                    ->addComment("@return iterable<array-key, {$out->fqcn}>");
             } else {
                 $interfaceMethod
                     ->setParameters([

--- a/src/Plugin/Generator/GrpcGenerator.php
+++ b/src/Plugin/Generator/GrpcGenerator.php
@@ -258,7 +258,7 @@ PHP,
                         new Parameter('cancellation')->setType('Cancellation'),
                     ])
                     ->setReturnType('iterable')
-                    ->addComment("@return iterable<array-key, {$out->fqcn}>");
+                    ->addComment("{$phpdocPrefix}@return iterable<array-key, {$out->fqcn}>");
             } else {
                 $interfaceMethod
                     ->setParameters([

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -1713,14 +1713,9 @@ interface QueueServiceServer
     ): \Google\Protobuf\Empty_;
 
     /**
-     * @param Server\ServerStreamChannel<\Thesis\Queue\PullRequest, \Thesis\Queue\PullRequest\Message> $stream
+     * @return iterable<array-key, \Thesis\Queue\PullRequest\Message>
      */
-    public function pull(
-        \Thesis\Queue\PullRequest $request,
-        Server\ServerStreamChannel $stream,
-        Metadata $md,
-        Cancellation $cancellation,
-    ): void;
+    public function pull(\Thesis\Queue\PullRequest $request, Metadata $md, Cancellation $cancellation): iterable;
 
     /**
      * @param Server\BidirectionalStreamChannel<\Thesis\Queue\Heartbeat\FromClient\Ping, \Thesis\Queue\Heartbeat\FromServer\Ping> $stream


### PR DESCRIPTION
Make server streaming server API more natural and less error-prone

Previously, server streaming handlers received a `ServerStreamChannel` and were responsible for explicitly calling `send()` and `close()` on it. This was error-prone — forgetting to call `close()` would leave the stream open indefinitely.

The new signature is:
```php
/**
 * @return iterable<array-key, Out>
 */
public function count(In $request, Metadata $md, Cancellation $cancellation): iterable;
```

The handler now simply returns an `iterable` — an array, a generator, or any other iterable, including an iterator backed by `Amp\Pipeline\Queue` for more advanced use cases. The framework takes care of sending each yielded value and closing the stream once the iterable is exhausted.

Examples:

```php
// Simple array

#[\Override]
public function words(Info $request, Metadata $md, Cancellation $cancellation): iterable
{
    return array_fill(0, $request->count, new Word(random_bytes(10)));
}

// Generator

#[\Override]
public function words(Info $request, Metadata $md, Cancellation $cancellation): iterable
{
    for ($i = 0; $i < $request->count; ++$i) {
        yield new Word(random_bytes(10));
    }
}

// Amp\Pipeline\Queue for async producers

#[\Override]
public function words(Info $request, Metadata $md, Cancellation $cancellation): iterable
{
    $queue = new \Amp\Pipeline\Queue();

    async(function() use ($queue, $request): void {
        try {
            for ($i = 0; $i < $request->count; ++$i) {
                $queue->push(new Word(random_bytes(10)));
            }
        } finally {
            $queue->complete();
        }
    });

    return $queue->iterate();
}
```