### PR TITLE
Fix plugin crash on large CodeGeneratorRequest input

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -23,6 +23,7 @@ $config = new Config()
 
 new PhpCsFixerCodingStandard()->applyTo($config, [
     'heredoc_indentation' => false,
+    'native_constant_invocation' => false,
 ]);
 
 return $config;

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "php": "^8.4",
         "ext-bcmath": "*",
         "ext-filter": "*",
-        "amphp/byte-stream": "^2.1",
         "nette/php-generator": "4.2.1",
         "thesis/package-version": "0.1.2",
         "thesis/protobuf": "^0.1.6",
@@ -31,9 +30,6 @@
     "require-dev": {
         "phpunit/phpunit": "^12.4",
         "symfony/var-dumper": "^8.0"
-    },
-    "conflict": {
-        "revolt/event-loop": "<0.2.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Io/ReadStreamInput.php
+++ b/src/Io/ReadStreamInput.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Thesis\Protoc\Io;
 
-use Amp\ByteStream;
 use Thesis\Protoc\Exception\InvalidInput;
 use Thesis\Protoc\ReadInput;
 
@@ -16,10 +15,12 @@ final readonly class ReadStreamInput implements ReadInput
     #[\Override]
     public function read(): string
     {
-        try {
-            return ByteStream\buffer(ByteStream\getStdin());
-        } catch (ByteStream\BufferException $e) {
-            throw new InvalidInput($e->getMessage(), $e->getCode(), $e);
+        $contents = stream_get_contents(\STDIN);
+
+        if ($contents === false) {
+            throw new InvalidInput('Failed to read from STDIN');
         }
+
+        return $contents;
     }
 }

--- a/src/Io/ReadStreamInput.php
+++ b/src/Io/ReadStreamInput.php
@@ -15,7 +15,7 @@ final readonly class ReadStreamInput implements ReadInput
     #[\Override]
     public function read(): string
     {
-        $contents = \stream_get_contents(\STDIN);
+        $contents = stream_get_contents(\STDIN);
 
         if ($contents === false) {
             throw new InvalidInput('Failed to read from STDIN');

--- a/src/Io/ReadStreamInput.php
+++ b/src/Io/ReadStreamInput.php
@@ -15,7 +15,7 @@ final readonly class ReadStreamInput implements ReadInput
     #[\Override]
     public function read(): string
     {
-        $contents = stream_get_contents(\STDIN);
+        $contents = \stream_get_contents(\STDIN);
 
         if ($contents === false) {
             throw new InvalidInput('Failed to read from STDIN');

--- a/src/Io/WriteStreamOutput.php
+++ b/src/Io/WriteStreamOutput.php
@@ -14,6 +14,6 @@ final readonly class WriteStreamOutput implements WriteOutput
     #[\Override]
     public function write(string $buffer): void
     {
-        \fwrite(\STDOUT, $buffer);
+        fwrite(\STDOUT, $buffer);
     }
 }

--- a/src/Io/WriteStreamOutput.php
+++ b/src/Io/WriteStreamOutput.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Thesis\Protoc\Io;
 
-use Amp\ByteStream;
 use Thesis\Protoc\WriteOutput;
 
 /**
@@ -15,6 +14,6 @@ final readonly class WriteStreamOutput implements WriteOutput
     #[\Override]
     public function write(string $buffer): void
     {
-        ByteStream\getStdout()->write($buffer);
+        \fwrite(\STDOUT, $buffer);
     }
 }


### PR DESCRIPTION
## Summary

- Replace amphp's non-blocking `ByteStream\buffer(ByteStream\getStdin())` with synchronous `stream_get_contents(STDIN)` to prevent premature EOF detection on pipe reads exceeding ~250KB

## Root cause

amphp's `ReadableResourceStream` sets STDIN to non-blocking mode and permanently closes the stream when `feof()` returns `true` — even transiently. On large pipe payloads that exceed the OS pipe buffer, `fread()` can drain the buffer faster than protoc writes, causing a spurious EOF. This is the same class of bug as [amphp/byte-stream#47](https://github.com/amphp/byte-stream/issues/47).

STDIN reading is inherently synchronous for protoc plugins (protoc sends the full request before expecting a response), so non-blocking I/O provides no benefit here.

Fixes #19