### PR TITLE
Add option to disable reflection metadata generation

### DIFF
--- a/src/Plugin/Compiler.php
+++ b/src/Plugin/Compiler.php
@@ -113,7 +113,7 @@ final readonly class Compiler
                 yield from $this->doGenerateMessages($generator, $descriptor);
             }
 
-            if (!$index->empty()) {
+            if ($options->emitMetadata && !$index->empty()) {
                 $descriptorName = Naming::descriptorName($source);
 
                 yield $generator->generateDescriptorMetadataRegistry(
@@ -128,7 +128,7 @@ final readonly class Compiler
             }
         }
 
-        foreach ($descriptorPaths->groupByNamespace() as $ns => $descriptors) {
+        foreach ($options->emitMetadata ? $descriptorPaths->groupByNamespace() : [] as $ns => $descriptors) {
             $generator = new AutoloadFunctionGenerator(
                 new FileFactory(
                     self::createAutoloadFileGeneratedDoc($request),

--- a/src/Plugin/CompilerOptions.php
+++ b/src/Plugin/CompilerOptions.php
@@ -16,6 +16,9 @@ final readonly class CompilerOptions
     private const string OPTION_GRPC = 'grpc';
     private const string GRPC_OPTION_CLIENT = 'client';
     private const string GRPC_OPTION_SERVER = 'server';
+    private const string OPTION_METADATA = 'metadata';
+    private const string METADATA_EMIT = 'emit';
+    private const string METADATA_NONE = 'none';
 
     public static function fromRequest(CodeGeneratorRequest $request): self
     {
@@ -33,12 +36,19 @@ final readonly class CompilerOptions
             self::GRPC_OPTION_SERVER,
         ];
 
+        $metadata = self::doGetString($parameters, self::OPTION_METADATA);
+
+        if ($metadata !== self::METADATA_EMIT && $metadata !== self::METADATA_NONE) {
+            $metadata = self::METADATA_EMIT;
+        }
+
         $requireGrpcClient = array_any($grpc, static fn(string $target) => $target === self::GRPC_OPTION_CLIENT);
         $requireGrpcServer = array_any($grpc, static fn(string $target) => $target === self::GRPC_OPTION_SERVER);
 
         return new self(
             requireGrpcClient: $requireGrpcClient,
             requireGrpcServer: $requireGrpcServer,
+            emitMetadata: $metadata === self::METADATA_EMIT,
             phpNamespace: self::doGetString($parameters, self::OPTION_PHP_NAMESPACE),
             srcPath: self::doGetString($parameters, self::OPTION_SRC_PATH),
         );
@@ -51,6 +61,7 @@ final readonly class CompilerOptions
     private function __construct(
         public bool $requireGrpcClient,
         public bool $requireGrpcServer,
+        public bool $emitMetadata,
         public ?string $phpNamespace = null,
         public ?string $srcPath = null,
     ) {}

--- a/tests/Plugin/CompilerOptionsTest.php
+++ b/tests/Plugin/CompilerOptionsTest.php
@@ -29,4 +29,15 @@ final class CompilerOptionsTest extends TestCase
         $options = CompilerOptions::fromRequest(new CodeGeneratorRequest(parameter: $parameter));
         self::assertSame($namespace, $options->phpNamespace);
     }
+
+    #[TestWith(['metadata=none', false])]
+    #[TestWith(['metadata=emit', true])]
+    #[TestWith(['metadata=none,metadata=emit', false])]
+    #[TestWith(['grpc=client,metadata=emit,grpc=server', true])]
+    #[TestWith(['grpc=client,metadata=none,grpc=server', false])]
+    public function testMetadata(string $parameter, bool $emitMetadata): void
+    {
+        $options = CompilerOptions::fromRequest(new CodeGeneratorRequest(parameter: $parameter));
+        self::assertSame($emitMetadata, $options->emitMetadata);
+    }
 }


### PR DESCRIPTION
Useful for projects that do not rely on protobuf reflection or dynamic message resolution (for example, libpg_query).